### PR TITLE
chore(cs): remove unneeded constructor naming check

### DIFF
--- a/src/Elgg/ruleset.xml
+++ b/src/Elgg/ruleset.xml
@@ -73,7 +73,6 @@
 	</rule>
 	<rule ref="Generic.Functions.OpeningFunctionBraceKernighanRitchie"/>
 
-	<rule ref="Generic.NamingConventions.ConstructorName"/>
 	<rule ref="Generic.NamingConventions.UpperCaseConstantName"/>
 
 	<rule ref="Generic.PHP.BacktickOperator"/>


### PR DESCRIPTION
Was deprecated in PHP 7 and no longer supported in PHP 8